### PR TITLE
Ensure theme patching applies to named themes

### DIFF
--- a/kodama.js
+++ b/kodama.js
@@ -264,6 +264,7 @@
         var _byDirection = defaultByDirection;
         var _by = defaultBy;
         var _theme = new _Theme(defaultTheme);
+        var _patch;
         var _holdDuration = defaultHoldDuration;
         var _fadeInDuration = defaultFadeInDuration;
         var _fadeOutDuration = defaultFadeOutDuration;
@@ -504,12 +505,14 @@
 
         _tooltip.theme = function(name){
             if(arguments.length === 0) return _theme;
-            _theme = themesByName[name];
+            _theme = new _Theme(themesByName[name]);
             return this;
         };
 
         _tooltip.patchTheme = function patchTheme (uiComp) {
-          _theme.patch(uiComp);
+          //_theme.patch(uiComp);
+          if(arguments.length === 0) return _patch;
+          _patch = uiComp;
           return this;
         };
 
@@ -604,6 +607,11 @@
                 tipDisplayData = (_formatFunc && _sourceData) ? _formatFunc(_sourceData, _sourceKey) : _sourceData;
 
                 _tooltip.options(tipDisplayData);
+
+                if (_patch) {
+                  _theme.patch(_patch);
+                }
+
                 _tooltip._build();
 
             }

--- a/kodama.js
+++ b/kodama.js
@@ -510,7 +510,6 @@
         };
 
         _tooltip.patchTheme = function patchTheme (uiComp) {
-          //_theme.patch(uiComp);
           if(arguments.length === 0) return _patch;
           _patch = uiComp;
           return this;


### PR DESCRIPTION
Given that you can pass a theme name via the tooltip options at "render" time, this change set ensures that your "inline styles" apply to tooltips styled via a named theme as well.
